### PR TITLE
feat: use unique storage id for wallet connect sessions

### DIFF
--- a/src/DeflyWalletConnect.ts
+++ b/src/DeflyWalletConnect.ts
@@ -131,6 +131,7 @@ class DeflyWalletConnect {
         // Create Connector instance
         this.connector = new WalletConnect({
           bridge: this.bridge || bridgeURL || 'https://bridge.walletconnect.org',
+          storageId: DEFLY_WALLET_LOCAL_STORAGE_KEYS.WALLETCONNECT,
           qrcodeModal: generateDeflyWalletConnectModalActions({
             shouldUseSound
           })
@@ -206,7 +207,8 @@ class DeflyWalletConnect {
 
         if (this.bridge) {
           this.connector = new WalletConnect({
-            bridge: this.bridge
+            bridge: this.bridge,
+            storageId: DEFLY_WALLET_LOCAL_STORAGE_KEYS.WALLETCONNECT,
           });
 
           resolve(this.connector?.accounts || []);

--- a/src/util/storage/storageConstants.ts
+++ b/src/util/storage/storageConstants.ts
@@ -1,6 +1,6 @@
 const DEFLY_WALLET_LOCAL_STORAGE_KEYS = {
   WALLET: "DeflyWallet.Wallet",
-  WALLETCONNECT: "walletconnect",
+  WALLETCONNECT: "DeflyWallet.WalletConnect",
   DEEP_LINK: "DeflyWallet.DeepLink",
   APP_META: "DeflyWallet.AppMeta",
   NETWORK: "DeflyWallet.Network"


### PR DESCRIPTION
In [@txnlab/use-wallet](https://github.com/TxnLab/use-wallet), we allow multiple providers to be connected at the same time. 

However, with providers based on `WalletConnect`, this isn't possible because they all use the default `walletconnect` key in browser storage to store metadata. This causes conflicts when multiple `WalletConnect` providers are connected (e.g., Pera, Defly, or a generic WalletConnect session). 

Passing in a unique `storageId` key to the `WalletConnect` constructor resolves this conflict.