### PR TITLE
fix: add vendor prefix to --vh CSS variable

### DIFF
--- a/src/modal/_defly-wallet-modal.scss
+++ b/src/modal/_defly-wallet-modal.scss
@@ -33,7 +33,7 @@
 
       width: calc(100% - 40px);
       max-width: unset;
-      height: calc(calc(100 * var(--vh)));
+      height: calc(100 * var(--defly-wallet-vh));
 
       padding: 20px;
 

--- a/src/util/screen/screenSizeUtils.ts
+++ b/src/util/screen/screenSizeUtils.ts
@@ -23,7 +23,7 @@ function isXSmallScreen() {
 function setVhVariable() {
   // a vh unit is equal to 1% of the screen height
   // eslint-disable-next-line no-magic-numbers
-  document.documentElement.style.setProperty("--vh", `${window.innerHeight * 0.01}px`);
+  document.documentElement.style.setProperty("--defly-wallet-vh", `${window.innerHeight * 0.01}px`);
 }
 
 export {isLargeScreen, isMediumScreen, isSmallScreen, isXSmallScreen, setVhVariable};


### PR DESCRIPTION
Setting a commonly-used global CSS variable like `--vh` from a third party library could lead to conflicts for app developers. This adds a prefix: `--defly-wallet-vh`.

See https://github.com/perawallet/connect/issues/160